### PR TITLE
fix: asyncio.run() in WorkFlow.execute() for proper task finalization

### DIFF
--- a/evoagentx/workflow/workflow.py
+++ b/evoagentx/workflow/workflow.py
@@ -42,21 +42,22 @@ class WorkFlow(BaseModule):
 
     def execute(self, inputs: dict = {}, **kwargs) -> str:
         """
-        Synchronous wrapper for async_execute. Creates a new event loop and runs the async method.
-        
+        Synchronous wrapper for async_execute.
+
+        Uses asyncio.run() so pending tasks are cancelled and async
+        generators / the default executor are finalized before the event
+        loop closes. Raises RuntimeError if called from a running event
+        loop; callers already inside an async context should await
+        async_execute() directly.
+
         Args:
             inputs: Dictionary of inputs for workflow execution
             **kwargs (Any): Additional keyword arguments
-            
+
         Returns:
             str: The output of the workflow execution
         """
-        loop = asyncio.new_event_loop()
-        asyncio.set_event_loop(loop)
-        try:
-            return loop.run_until_complete(self.async_execute(inputs, **kwargs))
-        finally:
-            loop.close()
+        return asyncio.run(self.async_execute(inputs, **kwargs))
 
     async def async_execute(self, inputs: dict = {}, **kwargs) -> str:
         """


### PR DESCRIPTION
# Use `asyncio.run()` in `WorkFlow.execute()` for proper task finalization

## Summary

`WorkFlow.execute()` currently uses `asyncio.new_event_loop()` + `loop.run_until_complete()` + `loop.close()`. This skips the task-cancellation and finalization that `asyncio.run()` performs, so any pending tasks at the moment `run_until_complete` returns are orphaned on a closed loop. Any library that spawns detached background tasks (LiteLLM's `LoggingWorker`, telemetry SDKs, httpx pool keep-alives, etc.) leaks these tasks every time a workflow runs. Replacing the hand-rolled wrapper with `asyncio.run(...)` eliminates the leak with a one-line change.

## Reproduction

Run any workflow that uses LiteLLM-routed models (the default for most users), then exit the process. Output includes one or more pairs of:

```
Task was destroyed but it is pending!
task: <Task pending name='Task-N' coro=<LoggingWorker._worker_loop() running at
       .../litellm/litellm_core_utils/logging_worker.py:121> ...>
Exception ignored in: <coroutine object LoggingWorker._worker_loop at 0x...>
Traceback (most recent call last):
  File ".../logging_worker.py", line 130, in _worker_loop
    self._sem.release()
AttributeError: 'NoneType' object has no attribute 'release'
```

Per-turn count of orphaned tasks scales with the number of `WorkFlow.execute()` calls in the session.

## Root cause

`evoagentx/workflow/workflow.py`, lines 43–59:

```python
def execute(self, inputs: dict = {}, **kwargs) -> str:
    loop = asyncio.new_event_loop()
    asyncio.set_event_loop(loop)
    try:
        return loop.run_until_complete(self.async_execute(inputs, **kwargs))
    finally:
        loop.close()
```

`loop.close()` is documented to "discard any pending callbacks"; it does not cancel pending tasks. `asyncio.run()`, by contrast, runs three finalization steps before closing the loop (see `Lib/asyncio/runners.py::Runner.close`):

1. `_cancel_all_tasks(loop)` — snapshot, cancel, gather every pending task
2. `loop.run_until_complete(loop.shutdown_asyncgens())` — close async generators
3. `loop.run_until_complete(loop.shutdown_default_executor())` — drain the thread pool

When a library like LiteLLM spawns a background `_worker_task` suspended on `await queue.get()`, the current implementation leaks that task; `asyncio.run()` cancels it, the worker's `except CancelledError:` handler runs its drain logic, and shutdown is clean.

## Fix

```diff
     def execute(self, inputs: dict = {}, **kwargs) -> str:
         """
-        Synchronous wrapper for async_execute. Creates a new event loop and runs the async method.
-
+        Synchronous wrapper for async_execute.
+
+        Uses asyncio.run() so pending tasks are cancelled and async
+        generators / the default executor are finalized before the event
+        loop closes. Raises RuntimeError if called from a running event
+        loop; callers already inside an async context should await
+        async_execute() directly.
+
         Args:
             inputs: Dictionary of inputs for workflow execution
             **kwargs (Any): Additional keyword arguments
-
+
         Returns:
             str: The output of the workflow execution
         """
-        loop = asyncio.new_event_loop()
-        asyncio.set_event_loop(loop)
-        try:
-            return loop.run_until_complete(self.async_execute(inputs, **kwargs))
-        finally:
-            loop.close()
+        return asyncio.run(self.async_execute(inputs, **kwargs))
```

## Why this is correct

`asyncio.run(coro)` is the documented entry point for running a coroutine from synchronous code (Python 3.7+, [asyncio docs](https://docs.python.org/3/library/asyncio-runner.html#asyncio.run)). Internally it does exactly what the current code does plus the three finalization steps listed above. Workflow execution semantics (HITL, agent manager, scheduling, output extraction) are entirely inside `async_execute()`, which is unchanged.

## Backward compatibility

One behavioral difference worth noting: `asyncio.run()` raises `RuntimeError: asyncio.run() cannot be called from a running event loop` when called from inside an already-running loop. The current implementation does not raise that specific error — it creates a fresh loop and tries to `run_until_complete` on it, which on Python 3.10+ raises `RuntimeError: This event loop is already running` from inside `run_until_complete`. So both code paths fail in this scenario; the new error message is clearer and points the caller at the correct API (`async_execute`). I do not consider this a breaking change.

For all other callers — i.e., synchronous code that wants to run a workflow to completion — behavior is identical except for the absence of the leak.

## Alternatives considered

- **Adding `_cancel_all_tasks` manually before `loop.close()`.** Works, but reinvents `asyncio.run`. No reason not to use the standard library primitive.
- **Catching `RuntimeError` and falling back to `loop = asyncio.get_event_loop(); loop.run_until_complete(...)` if a loop is already running.** Would silently let `execute()` work from async contexts, but `async_execute()` already exists for that purpose. Hiding the distinction encourages misuse from async code, where a synchronous wrapper is the wrong abstraction.

## Test plan

- All existing workflow tests pass — `async_execute` is unchanged and is what `execute` already invokes.
- Manual reproduction: run any workflow that talks to a LiteLLM-routed model, exit, observe absence of the `Task was destroyed but it is pending` lines.
- If a regression test is desired, `pytest-asyncio` can detect orphaned tasks via `event_loop.fixture` introspection, but I'd suggest leaving that out of this PR to keep it minimal.

## Scope

The same anti-pattern was searched for across non-test code in the repo:

```
$ grep -rn "new_event_loop\|run_until_complete" evoagentx/ --include="*.py" | grep -v test
evoagentx/workflow/workflow.py:54:        loop = asyncio.new_event_loop()
evoagentx/workflow/workflow.py:57:            return loop.run_until_complete(self.async_execute(inputs, **kwargs))
```

`WorkFlow.execute` is the only occurrence. No related changes needed.