### PR TITLE
fix(evoprompt): isolate registry state during concurrent evaluation

### DIFF
--- a/evoagentx/optimizers/engine/base.py
+++ b/evoagentx/optimizers/engine/base.py
@@ -1,7 +1,12 @@
-from typing import Any, Callable, Dict, List, Optional
+from __future__ import annotations
+
 import abc
+from typing import Any, Callable, Dict, List, Optional, TYPE_CHECKING
+
 from .decorators import EntryPoint
-from .registry import ParamRegistry
+
+if TYPE_CHECKING:
+    from .registry import ParamRegistry
 
 class BaseOptimizer(abc.ABC):
     # def __init__(

--- a/evoagentx/optimizers/engine/decorators.py
+++ b/evoagentx/optimizers/engine/decorators.py
@@ -1,5 +1,9 @@
-from typing import Any, Callable, List, Tuple, Optional
-from .registry import ParamRegistry
+from __future__ import annotations
+
+from typing import Any, Callable, List, Tuple, Optional, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .registry import ParamRegistry
 
 # --------- EntryPoint decorator ---------
 class EntryPoint:

--- a/evoagentx/optimizers/evoprompt_optimizer.py
+++ b/evoagentx/optimizers/evoprompt_optimizer.py
@@ -12,6 +12,8 @@
 #   https://opensource.microsoft.com/codeofconduct/
 # -----------------------------------------------------------------------------
 
+from __future__ import annotations
+
 import asyncio
 import json
 import random
@@ -20,19 +22,19 @@ import os
 import csv
 import time
 import itertools
-from typing import Callable, Dict, List
+from typing import Callable, Dict, List, TYPE_CHECKING
 from datetime import datetime
 
 import numpy as np
 from tqdm.asyncio import tqdm as aio_tqdm
-import matplotlib.pyplot as plt
 
-from evoagentx.agents import CustomizeAgent
-from evoagentx.benchmark.bigbenchhard import BIGBenchHard
 from evoagentx.core.logging import logger
-from evoagentx.models import OpenAILLMConfig
 from evoagentx.optimizers.engine.base import BaseOptimizer
-from evoagentx.optimizers.engine.registry import ParamRegistry
+
+if TYPE_CHECKING:
+    from evoagentx.benchmark.bigbenchhard import BIGBenchHard
+    from evoagentx.models import OpenAILLMConfig
+    from evoagentx.optimizers.engine.registry import ParamRegistry
 
 
 class EvopromptOptimizer(BaseOptimizer):
@@ -77,6 +79,7 @@ class EvopromptOptimizer(BaseOptimizer):
         self.iterations = iterations
         self.llm_config = llm_config
         self.semaphore = asyncio.Semaphore(concurrency_limit)
+        self._program_config_lock = asyncio.Lock()
         self.combination_sample_size = combination_sample_size
 
         # Logging configuration
@@ -100,6 +103,7 @@ class EvopromptOptimizer(BaseOptimizer):
         self.avg_combo_scores_per_gen: Dict[str, float] = {}
         
         # Initialize paraphrase agent for prompt generation
+        from evoagentx.agents import CustomizeAgent
         self.paraphrase_agent = CustomizeAgent(
             name="ParaphraseAgent",
             description="An agent that paraphrases a given instruction.",
@@ -215,6 +219,8 @@ Please provide the paraphrased version in the following format:
     def _create_single_metric_plot(self, metric_name: str, generations: List[int],
                                    best_scores: List[float], avg_scores: List[float],
                                    algorithm_name: str, plot_dir: str):
+        import matplotlib.pyplot as plt
+
         fig, ax = plt.subplots(figsize=(12, 7))
         ax.plot(generations, best_scores, marker='o', linestyle='-', linewidth=2, markersize=8, label='Best Score')
         ax.plot(generations, avg_scores, marker='x', linestyle='--', linewidth=2, markersize=8, label='Average Score')
@@ -242,9 +248,12 @@ Please provide the paraphrased version in the following format:
             plt.close(fig)
 
     def _plot_and_save_performance_graph(self, algorithm_name: str):
-        if not self.enable_logging or plt is None:
-            if plt is None:
-                logger.warning("Matplotlib not found, skipping plot generation.")
+        if not self.enable_logging:
+            return
+        try:
+            import matplotlib.pyplot as plt
+        except ImportError:
+            logger.warning("Matplotlib not found, skipping plot generation.")
             return
         if not self.best_scores_per_gen and not self.best_combo_scores_per_gen:
             logger.warning("No performance data to plot.")
@@ -460,8 +469,7 @@ Please provide the paraphrased version in the following format:
         all_scores = []
         pbar = aio_tqdm(total=len(combinations), desc="Evaluating batch", leave=False)
         for combo in combinations:
-            tasks = [self._evaluate_combination_on_example(combo, benchmark, ex) for ex in eval_dev_set]
-            example_scores = await asyncio.gather(*tasks)
+            example_scores = await self._evaluate_combination_on_examples(combo, benchmark, eval_dev_set)
             avg_score = sum(example_scores) / len(example_scores) if example_scores else 0.0
             all_scores.append(avg_score)
             pbar.update(1)
@@ -507,37 +515,70 @@ Please provide the paraphrased version in the following format:
         logger.info(f"Generated {len(sampled_combinations)} unique combinations")
         return sampled_combinations
 
-    async def _evaluate_combination_on_example(self, combination: Dict[str, str],
-                                             benchmark: BIGBenchHard, example: Dict) -> float:
+    def _get_eval_cache_key(self, combination: Dict[str, str], example: Dict):
         combo_key = tuple(sorted(combination.items()))
         example_key = str(hash(str(example)))
-        cache_key = hash((combo_key, example_key))
+        return hash((combo_key, example_key))
 
-        if not hasattr(self, '_eval_cache'):
-            self._eval_cache = {}
+    def _cache_eval_score(self, cache_key, score: float):
+        self._eval_cache[cache_key] = score
+        if len(self._eval_cache) > 5000:
+            keys_to_del = list(self._eval_cache.keys())[:1000]
+            for key in keys_to_del:
+                del self._eval_cache[key]
 
-        if cache_key in self._eval_cache:
-            return self._eval_cache[cache_key]
-
+    async def _evaluate_current_config_on_example(self, benchmark: BIGBenchHard, example: Dict) -> float:
         async with self.semaphore:
             try:
-                original_config = self.get_current_cfg()
-                self.apply_cfg(combination)
                 inputs = {k: v for k, v in example.items() if k in benchmark.get_input_keys()}
                 prediction, _ = await asyncio.to_thread(self.program, **inputs)
                 label = benchmark.get_label(example)
                 score_dict = benchmark.evaluate(prediction, label)
-                score = score_dict.get("em", 0.0)
-                self.apply_cfg(original_config)
-                self._eval_cache[cache_key] = score
-                if len(self._eval_cache) > 5000:
-                    keys_to_del = list(self._eval_cache.keys())[:1000]
-                    for key in keys_to_del:
-                        del self._eval_cache[key]
-                return score
+                return score_dict.get("em", 0.0)
             except Exception as e:
                 logger.error(f"Error evaluating combination: {e}")
                 return 0.0
+
+    async def _evaluate_combination_on_examples(self, combination: Dict[str, str],
+                                                benchmark: BIGBenchHard, examples: List[Dict]) -> List[float]:
+        if not examples:
+            return []
+
+        if not hasattr(self, '_eval_cache'):
+            self._eval_cache = {}
+
+        scores = [0.0] * len(examples)
+        pending_examples = []
+        for idx, example in enumerate(examples):
+            cache_key = self._get_eval_cache_key(combination, example)
+            if cache_key in self._eval_cache:
+                scores[idx] = self._eval_cache[cache_key]
+            else:
+                pending_examples.append((idx, cache_key, example))
+
+        if pending_examples:
+            async with self._program_config_lock:
+                original_config = self.get_current_cfg()
+                try:
+                    self.apply_cfg(combination)
+                    tasks = [
+                        self._evaluate_current_config_on_example(benchmark, example)
+                        for _, _, example in pending_examples
+                    ]
+                    evaluated_scores = await asyncio.gather(*tasks)
+                finally:
+                    self.apply_cfg(original_config)
+
+            for (idx, cache_key, _), score in zip(pending_examples, evaluated_scores):
+                scores[idx] = score
+                self._cache_eval_score(cache_key, score)
+
+        return scores
+
+    async def _evaluate_combination_on_example(self, combination: Dict[str, str],
+                                             benchmark: BIGBenchHard, example: Dict) -> float:
+        scores = await self._evaluate_combination_on_examples(combination, benchmark, [example])
+        return scores[0] if scores else 0.0
 
     async def _evaluate_combinations_and_update_node_scores(self, combinations: List[Dict[str, str]],
                                                           benchmark: BIGBenchHard, dev_set: list) -> List[float]:
@@ -546,8 +587,7 @@ Please provide the paraphrased version in the following format:
         print(f"Evaluating {len(combinations)} combinations on {len(eval_dev_set)} examples...")
         combo_pbar = aio_tqdm(total=len(combinations), desc="Evaluating Combinations")
         for combination in combinations:
-            tasks = [self._evaluate_combination_on_example(combination, benchmark, ex) for ex in eval_dev_set]
-            example_scores = await asyncio.gather(*tasks)
+            example_scores = await self._evaluate_combination_on_examples(combination, benchmark, eval_dev_set)
             avg_score = sum(example_scores) / len(example_scores) if example_scores else 0.0
             combination_scores.append(avg_score)
             combo_pbar.update(1)
@@ -687,6 +727,7 @@ class GAOptimizer(EvopromptOptimizer):
         logger.info(f"GAOptimizer initialized with '{mode_str}' mode.")
         
         # Initialize genetic algorithm agent for prompt evolution
+        from evoagentx.agents import CustomizeAgent
         self.ga_agent = CustomizeAgent(
             name="ga_agent",
             description="An agent that evolves a new prompt from two parent prompts.",
@@ -961,6 +1002,7 @@ class DEOptimizer(EvopromptOptimizer):
         super().__init__(*args, **kwargs)
         
         # Initialize differential evolution agent for prompt mutation
+        from evoagentx.agents import CustomizeAgent
         self.de_agent = CustomizeAgent(
             name="DE_Agent",
             description="Generates a new trial prompt using the Differential Evolution strategy.",

--- a/tests/src/optimizers/test_evoprompt_state_isolation.py
+++ b/tests/src/optimizers/test_evoprompt_state_isolation.py
@@ -1,0 +1,185 @@
+import asyncio
+import threading
+
+import pytest
+
+from evoagentx.optimizers.engine.base import BaseOptimizer
+from evoagentx.optimizers.evoprompt_optimizer import EvopromptOptimizer
+
+
+class FakeBenchmark:
+    def get_input_keys(self):
+        return ["case"]
+
+    def get_label(self, example):
+        return example["target"]
+
+    def evaluate(self, prediction, label):
+        return {"em": float(prediction == label)}
+
+
+class RaisingBenchmark(FakeBenchmark):
+    def evaluate(self, prediction, label):
+        raise RuntimeError("evaluation failed")
+
+
+class SimpleProgram:
+    def __init__(self):
+        self.prompt = "base"
+
+    def __call__(self, case):
+        return self.prompt, {"case": case}
+
+
+class PromptRegistry:
+    def __init__(self, program):
+        self.program = program
+        self.fields = {"prompt": object()}
+
+    def get(self, name):
+        assert name == "prompt"
+        return self.program.prompt
+
+    def set(self, name, value):
+        assert name == "prompt"
+        self.program.prompt = value
+
+    def names(self):
+        return ["prompt"]
+
+
+class CoordinatedExampleProgram:
+    def __init__(self):
+        self._prompt = "base"
+        self.slow_started = threading.Event()
+        self.fast_returned = threading.Event()
+        self.base_restored_after_fast = threading.Event()
+        self.observed = {}
+
+    @property
+    def prompt(self):
+        return self._prompt
+
+    @prompt.setter
+    def prompt(self, value):
+        self._prompt = value
+        if value == "base" and self.fast_returned.is_set():
+            self.base_restored_after_fast.set()
+
+    def __call__(self, case):
+        if case == "fast":
+            self.slow_started.wait(timeout=1.0)
+            observed = self.prompt
+            self.observed[case] = observed
+            self.fast_returned.set()
+            return observed, {"case": case}
+
+        if case == "slow":
+            self.slow_started.set()
+            self.fast_returned.wait(timeout=1.0)
+            self.base_restored_after_fast.wait(timeout=0.05)
+            observed = self.prompt
+            self.observed[case] = observed
+            return observed, {"case": case}
+
+        observed = self.prompt
+        self.observed[case] = observed
+        return observed, {"case": case}
+
+
+class CrossCombinationProgram:
+    def __init__(self):
+        self.prompt = "base"
+        self.combo_a_entered = threading.Event()
+        self.combo_b_entered = threading.Event()
+        self.observed = []
+
+    def __call__(self, case):
+        initial_prompt = self.prompt
+        if initial_prompt == "combo-a":
+            self.combo_a_entered.set()
+            self.combo_b_entered.wait(timeout=0.05)
+        elif initial_prompt == "combo-b":
+            self.combo_b_entered.set()
+            self.combo_a_entered.wait(timeout=0.05)
+
+        observed = self.prompt
+        self.observed.append((case, initial_prompt, observed))
+        return observed, {"case": case}
+
+
+def make_optimizer(program, concurrency_limit=2):
+    registry = PromptRegistry(program)
+
+    class TestOptimizer(EvopromptOptimizer):
+        def __init__(self):
+            BaseOptimizer.__init__(self, registry=registry, program=program)
+            self.semaphore = asyncio.Semaphore(concurrency_limit)
+            self._program_config_lock = asyncio.Lock()
+            self._eval_cache = {}
+
+        async def optimize(self):
+            return None
+
+    return TestOptimizer()
+
+
+@pytest.mark.asyncio
+async def test_combination_config_is_kept_until_all_examples_finish():
+    program = CoordinatedExampleProgram()
+    optimizer = make_optimizer(program, concurrency_limit=2)
+    benchmark = FakeBenchmark()
+
+    scores = await optimizer._evaluate_combination_on_examples(
+        {"prompt": "optimized"},
+        benchmark,
+        [
+            {"case": "fast", "target": "optimized"},
+            {"case": "slow", "target": "optimized"},
+        ],
+    )
+
+    assert scores == [1.0, 1.0]
+    assert program.observed == {"fast": "optimized", "slow": "optimized"}
+    assert program.prompt == "base"
+
+
+@pytest.mark.asyncio
+async def test_combination_config_is_restored_after_evaluation_error():
+    program = SimpleProgram()
+    optimizer = make_optimizer(program)
+
+    scores = await optimizer._evaluate_combination_on_examples(
+        {"prompt": "optimized"},
+        RaisingBenchmark(),
+        [{"case": "single", "target": "optimized"}],
+    )
+
+    assert scores == [0.0]
+    assert program.prompt == "base"
+
+
+@pytest.mark.asyncio
+async def test_concurrent_combinations_do_not_share_temporary_config():
+    program = CrossCombinationProgram()
+    optimizer = make_optimizer(program, concurrency_limit=2)
+    benchmark = FakeBenchmark()
+
+    scores_a, scores_b = await asyncio.gather(
+        optimizer._evaluate_combination_list(
+            [{"prompt": "combo-a"}],
+            benchmark,
+            [{"case": "a", "target": "combo-a"}],
+        ),
+        optimizer._evaluate_combination_list(
+            [{"prompt": "combo-b"}],
+            benchmark,
+            [{"case": "b", "target": "combo-b"}],
+        ),
+    )
+
+    assert scores_a == [1.0]
+    assert scores_b == [1.0]
+    assert ("a", "combo-a", "combo-a") in program.observed
+    assert ("b", "combo-b", "combo-b") in program.observed
+    assert program.prompt == "base"


### PR DESCRIPTION
## Motivation

Fixes #252.

EvoPrompt temporarily applies a candidate prompt configuration to the shared `ParamRegistry` before evaluating the program, then restores the previous configuration afterwards.

Because evaluations are run concurrently and `ParamRegistry` mutates the live program state, concurrent evaluation tasks can interleave. This can make one prompt combination get scored under another registry state, and can also leave the program in a temporary configuration when restoration interleaves with another task or when evaluation raises.

## Summary

- Isolate temporary EvoPrompt registry mutation with a per-optimizer async lock.
- Apply a combination once while evaluating its examples, then restore the original config in a `finally` block.
- Keep example-level execution concurrent for the active combination.
- Separate current-config example evaluation from registry mutation.
- Defer type-only/heavy imports used by optimizer modules so targeted EvoPrompt tests do not need unrelated optional dependencies at import time.
- Add deterministic async tests for registry state isolation and exception recovery.

## Tests

```bash
.venv/bin/python -m pytest tests/src/optimizers/test_evoprompt_state_isolation.py tests/src/optimizers/test_optimizer_package_imports.py -q
```

```text
4 passed
```

```bash
.venv/bin/python -m ruff check evoagentx/optimizers/evoprompt_optimizer.py evoagentx/optimizers/engine/base.py evoagentx/optimizers/engine/decorators.py tests/src/optimizers/test_evoprompt_state_isolation.py
```

```text
All checks passed!
```

## Notes

This serializes temporary config mutation across different prompt combinations. Example-level program execution for the active combination can still run concurrently. This prioritizes correctness of EvoPrompt fitness scores over unsafe cross-combination mutation of shared program state.
