### PR TITLE
fix(alita): preserve generated tool results with stdout logs

### DIFF
--- a/evoagentx/tools/alita_agent.py
+++ b/evoagentx/tools/alita_agent.py
@@ -1,16 +1,15 @@
 import json
 import os
-from typing import Any, Dict, List, Optional
+import uuid
+from typing import TYPE_CHECKING, Any, ClassVar, Dict, List, Optional
 
 from ..core.logging import logger
-from ..models.model_configs import LLMConfig
-from ..agents import CustomizeAgent
 
 from .tool import Tool, Toolkit
-from .storage_file import StorageToolkit
-from .search_serpapi import SerpAPIToolkit
-from .interpreter_docker import DockerInterpreterToolkit
-from .interpreter_python import PythonInterpreterToolkit
+
+if TYPE_CHECKING:
+    from ..agents import CustomizeAgent
+    from ..models.model_configs import LLMConfig
 
 
 class GeneratedCodeTool(Tool):
@@ -43,6 +42,8 @@ class GeneratedCodeTool(Tool):
         }
     }
     required: Optional[List[str]] = []
+    _RESULT_MARKER_PREFIX: ClassVar[str] = "__ALITA_GENERATED_TOOL_RESULT__"
+    _RESULT_MARKER: ClassVar[str] = "__ALITA_GENERATED_TOOL_RESULT__="
 
     def __init__(
         self,
@@ -77,12 +78,17 @@ class GeneratedCodeTool(Tool):
 
         # Inject payload and user code into a small wrapper that expects the
         # user to set `result` and prints it as JSON.
+        result_marker = f"{self._RESULT_MARKER_PREFIX}_{uuid.uuid4().hex}="
         wrapper_code = (
-            "import json\n\n"
-            f"payload = json.loads({json.dumps(payload_json)})\n\n"
+            "import json as __alita_json\n\n"
+            f"payload = __alita_json.loads({json.dumps(payload_json)})\n\n"
             "result = None\n\n"
             f"{self._source_code}\n\n"
-            "print(json.dumps(result, ensure_ascii=False))\n"
+            "import json as __alita_json\n"
+            "print("
+            f"{json.dumps(result_marker)} + "
+            "__alita_json.dumps(result, ensure_ascii=False)"
+            ")\n"
         )
 
         try:
@@ -101,7 +107,49 @@ class GeneratedCodeTool(Tool):
                 "error": "Code executor returned no output for generated tool.",
             }
 
-        # Try to parse the output as JSON; if that fails, return raw text.
+        # Parse the wrapper's marked result while preserving user stdout logs.
+        return self._parse_execution_output(output, marker=result_marker)
+
+    @classmethod
+    def _parse_execution_output(
+        cls, output: str, marker: Optional[str] = None
+    ) -> Dict[str, Any]:
+        result_marker = marker or cls._RESULT_MARKER
+        marker_index = output.rfind(result_marker)
+        failed_result_text = None
+        while marker_index != -1:
+            result_start = marker_index + len(result_marker)
+            line_end = output.find("\n", result_start)
+            if line_end == -1:
+                line_end = len(output)
+                after_result = ""
+            else:
+                after_result = output[line_end + 1 :]
+
+            result_text = output[result_start:line_end].strip()
+            try:
+                parsed = json.loads(result_text)
+            except Exception:
+                failed_result_text = result_text
+            else:
+                result = {
+                    "success": True,
+                    "result": parsed,
+                    "raw_output": output,
+                }
+                logs = (output[:marker_index] + after_result).strip()
+                if logs:
+                    result["logs"] = logs
+                return result
+            marker_index = output.rfind(result_marker, 0, marker_index)
+
+        if failed_result_text is not None:
+            logger.warning(
+                "Failed to parse marked generated tool result as JSON: {}",
+                failed_result_text,
+            )
+
+        # Backward-compatible fallback for unmarked executor output.
         try:
             parsed = json.loads(output)
             return {
@@ -110,10 +158,12 @@ class GeneratedCodeTool(Tool):
                 "raw_output": output,
             }
         except Exception:
-            return {
-                "success": True,
-                "result": output,
-            }
+            pass
+
+        return {
+            "success": True,
+            "result": output,
+        }
 
 
 class AlitaDynamicToolkit(Toolkit):
@@ -509,13 +559,13 @@ class ReloadDynamicTools(Tool):
 
 
 def create_alita_agent(
-    llm_config: LLMConfig,
+    llm_config: "LLMConfig",
     persist_dynamic_tools: bool = True,
     load_existing_dynamic_tools: bool = True,
     dynamic_tools_path: str = "./workplace/alita/dynamic_tools.json",
     use_docker: bool = True,
     serpapi_api_key: Optional[str] = None,
-) -> CustomizeAgent:
+) -> "CustomizeAgent":
     """
     Build the Alita agent with search, storage, code execution, and dynamic tools.
 
@@ -543,6 +593,12 @@ def create_alita_agent(
             the SerpAPIToolkit will fall back to the SERPAPI_KEY environment
             variable.
     """
+
+    from ..agents import CustomizeAgent
+    from .interpreter_docker import DockerInterpreterToolkit
+    from .interpreter_python import PythonInterpreterToolkit
+    from .search_serpapi import SerpAPIToolkit
+    from .storage_file import StorageToolkit
 
     # Search toolkit (SerpAPI)
     serp_toolkit = SerpAPIToolkit(
@@ -638,7 +694,7 @@ def create_alita_agent(
     return agent
 
 
-def alita_agent(*args, **kwargs) -> CustomizeAgent:
+def alita_agent(*args, **kwargs) -> "CustomizeAgent":
     """
     Convenience wrapper for :func:`create_alita_agent`.
 

--- a/tests/src/tools/test_alita_generated_code_tool.py
+++ b/tests/src/tools/test_alita_generated_code_tool.py
@@ -1,0 +1,154 @@
+import contextlib
+import io
+from pathlib import Path
+from typing import Dict, List, Optional
+
+from evoagentx.tools.alita_agent import GeneratedCodeTool
+from evoagentx.tools.interpreter_python import PythonExecuteTool, PythonInterpreter
+from evoagentx.tools.tool import Tool
+
+
+class FakePythonExecutor(Tool):
+    name: str = "fake_python_execute"
+    description: str = "Execute Python code and return stdout."
+    inputs: Dict[str, Dict[str, str]] = {
+        "code": {"type": "string", "description": "Python source code."},
+        "language": {"type": "string", "description": "Execution language."},
+    }
+    required: Optional[List[str]] = ["code"]
+
+    def __call__(self, code: str, language: str = "python") -> str:
+        stdout = io.StringIO()
+        with contextlib.redirect_stdout(stdout):
+            exec(code, {})
+        return stdout.getvalue()
+
+
+class AppendingPythonExecutor(FakePythonExecutor):
+    name: str = "appending_python_execute"
+    description: str = "Execute Python code and append output after execution."
+    inputs: Dict[str, Dict[str, str]] = {
+        "code": {"type": "string", "description": "Python source code."},
+        "language": {"type": "string", "description": "Execution language."},
+    }
+    required: Optional[List[str]] = ["code"]
+
+    def __call__(self, code: str, language: str = "python") -> str:
+        return super().__call__(code, language) + "stderr: warning\n"
+
+
+class MarkerCollisionPythonExecutor(FakePythonExecutor):
+    name: str = "marker_collision_python_execute"
+    description: str = "Execute Python code and append a colliding marker line."
+    inputs: Dict[str, Dict[str, str]] = {
+        "code": {"type": "string", "description": "Python source code."},
+        "language": {"type": "string", "description": "Execution language."},
+    }
+    required: Optional[List[str]] = ["code"]
+
+    def __call__(self, code: str, language: str = "python") -> str:
+        marker_start = code.rfind(GeneratedCodeTool._RESULT_MARKER_PREFIX)
+        marker_end = code.find("=", marker_start)
+        assert marker_start != -1
+        assert marker_end != -1
+        marker = code[marker_start : marker_end + 1]
+        return super().__call__(code, language) + f"{marker}not-json\n"
+
+
+def test_generated_code_tool_returns_structured_result_without_logs():
+    tool = GeneratedCodeTool(
+        code_executor=FakePythonExecutor(),
+        tool_name="clean_tool",
+        description="Clean generated tool",
+        code='result = {"echo": payload.get("text")}',
+    )
+
+    output = tool(payload={"text": "hello"})
+
+    assert output["success"] is True
+    assert output["result"] == {"echo": "hello"}
+    assert output["raw_output"]
+    assert "logs" not in output
+
+
+def test_generated_code_tool_separates_stdout_logs_from_result():
+    tool = GeneratedCodeTool(
+        code_executor=FakePythonExecutor(),
+        tool_name="noisy_tool",
+        description="Noisy generated tool",
+        code='print("debug: starting")\nresult = {"echo": payload.get("text")}',
+    )
+
+    output = tool(payload={"text": "hello"})
+
+    assert output["success"] is True
+    assert output["result"] == {"echo": "hello"}
+    assert output["logs"] == "debug: starting"
+    assert "debug: starting" in output["raw_output"]
+
+
+def test_generated_code_tool_handles_output_after_marked_result():
+    tool = GeneratedCodeTool(
+        code_executor=AppendingPythonExecutor(),
+        tool_name="stderr_tool",
+        description="Generated tool with post-result output",
+        code='print("debug: starting")\nresult = {"echo": payload.get("text")}',
+    )
+
+    output = tool(payload={"text": "hello"})
+
+    assert output["success"] is True
+    assert output["result"] == {"echo": "hello"}
+    assert output["logs"] == "debug: starting\nstderr: warning"
+
+
+def test_generated_code_tool_ignores_invalid_marker_collision_after_result():
+    tool = GeneratedCodeTool(
+        code_executor=MarkerCollisionPythonExecutor(),
+        tool_name="collision_tool",
+        description="Generated tool with a post-result marker collision",
+        code='print("debug: starting")\nresult = {"echo": payload.get("text")}',
+    )
+
+    output = tool(payload={"text": "hello"})
+
+    assert output["success"] is True
+    assert output["result"] == {"echo": "hello"}
+    assert output["logs"].startswith("debug: starting\n")
+    assert "not-json" in output["logs"]
+
+
+def test_generated_code_tool_preserves_legacy_full_json_output():
+    output = GeneratedCodeTool._parse_execution_output('{"echo": "hello"}')
+
+    assert output["success"] is True
+    assert output["result"] == {"echo": "hello"}
+    assert output["raw_output"] == '{"echo": "hello"}'
+
+
+def test_generated_code_tool_does_not_guess_from_unmarked_json_log():
+    raw_output = '{"debug": true}\nTraceback (most recent call last):\nboom'
+
+    output = GeneratedCodeTool._parse_execution_output(raw_output)
+
+    assert output["success"] is True
+    assert output["result"] == raw_output
+
+
+def test_generated_code_tool_separates_stdout_logs_with_python_interpreter():
+    repo_root = Path(__file__).resolve().parents[3]
+    python_executor = PythonExecuteTool(
+        python_interpreter=PythonInterpreter(project_path=str(repo_root))
+    )
+    tool = GeneratedCodeTool(
+        code_executor=python_executor,
+        tool_name="real_python_tool",
+        description="Generated tool using the real Python executor",
+        code='print("debug: starting")\nresult = {"echo": payload.get("text")}',
+    )
+
+    output = tool(payload={"text": "hello"})
+
+    assert output["success"] is True
+    assert output["result"] == {"echo": "hello"}
+    assert output["logs"] == "debug: starting"


### PR DESCRIPTION
## Summary
- add a unique result marker for Alita generated tools so user stdout logs do not break result parsing
- preserve stdout/stderr logs separately while returning the structured generated tool result
- keep legacy full-JSON output compatibility and avoid guessing JSON from unmarked mixed output
- add regression coverage for noisy stdout, post-result output, marker collisions, legacy JSON output, and the real Python executor

Closes #255

## Tests
- `.venv/bin/python -m pytest tests/src/tools/test_alita_generated_code_tool.py -q`
- `.venv/bin/python -m pytest tests/src/tools/test_alita_generated_code_tool.py tests/src/core/test_dependency_extras.py -q`
- `.venv/bin/python -m ruff check evoagentx/tools/alita_agent.py tests/src/tools/test_alita_generated_code_tool.py`
- `git diff --check`